### PR TITLE
Fix versions considered vulnerable for CVE-2024-2242

### DIFF
--- a/nuclei-templates/2024/CVE-2024-2242-8b36c4ecd0a0c68d6b11572547227a00.yaml
+++ b/nuclei-templates/2024/CVE-2024-2242-8b36c4ecd0a0c68d6b11572547227a00.yaml
@@ -56,4 +56,4 @@ http:
 
       - type: dsl
         dsl:
-          - compare_versions(version, '<= 5.9')
+          - compare_versions(version, '>= 5.9.0', '<=5.9.1')


### PR DESCRIPTION
Despite the CVE description from NIST, only version 5.9 is vulnerable to this CVE. 

In this reference [1] from NIST [2] we can see the fix for the vulnerability.

![image](https://github.com/topscoder/nuclei-wordfence-cve/assets/22767204/ee26d53d-106d-4ab9-a9a0-d14770b03e76)

However, looking with in the commit history for the `admin/edit-contact-form.php` we can see the commit which introduced this bug [3]. This commit has been made with one month prior to the fix, so the vulnerability only exists in versions 5.9.0 and 5.9.1 of the plugin.

![commit](https://github.com/topscoder/nuclei-wordfence-cve/assets/22767204/06b148b6-9989-43a0-aaa6-9823466351a8)

[1] https://plugins.trac.wordpress.org/changeset/3049594/contact-form-7/trunk/admin/edit-contact-form.php
[2] https://nvd.nist.gov/vuln/detail/CVE-2024-2242
[3] https://github.com/rocklobster-in/contact-form-7/commit/2c5f09afcb1104603b2c528e1d472f66a17ec3f7